### PR TITLE
Add Playtest support

### DIFF
--- a/Erenshor-Achievement-Mod/Mod.cs
+++ b/Erenshor-Achievement-Mod/Mod.cs
@@ -15,6 +15,40 @@ namespace Erenshor_Achievement_Mod
 
     public class Mod : MelonMod
     {
+        private static string[] ValidScenes = new string[]
+        {
+            "Stowaway",
+            "Brake",
+            "Bonepits",
+            "Vitheo",
+            "Krakengard",
+            "FernallaField",
+            "SaltedStrand",
+            "Elderstone",
+            "Azure",
+            "Rottenfoot",
+            "Braxonian",
+            "Silkengrass",
+            "Underspine",
+            "Loomingwood",
+            "Duskenlight",
+            "Windwashed",
+            "Blight",
+            "Malaroth",
+            "Braxonia",
+            "Soluna",
+            "Ripper",
+            "Abyssal",
+            "VitheosEnd",
+            "Azynthi",
+            "AzynthiClear",
+            "DuskenPortal",
+            "Rockshade",
+            "ShiveringTomb",
+            "Undercity",
+            "Jaws"
+        };
+
         public override async void OnLateInitializeMelon()
         {
             await Database.CreateLocalDatabase();
@@ -40,7 +74,7 @@ namespace Erenshor_Achievement_Mod
 
         private static bool IsValidScene(string sceneName)
         {
-            return sceneName == "Stowaway";
+            return ValidScenes.Contains(sceneName);
         }
         
         private static async Task LoadupAchievements()


### PR DESCRIPTION
This pull request includes changes to the `Erenshor-Achievement-Mod` to enhance the scene validation mechanism by introducing a comprehensive list of valid scenes and updating the scene validation logic.

Enhancements to scene validation:

* [`Erenshor-Achievement-Mod/Mod.cs`](diffhunk://#diff-e74552123ebf64555f0d550b7ecc087475a498259f3d96ac96dc6a8af4f1679eR18-R51): Added a static array `ValidScenes` containing the names of all valid scenes.
* [`Erenshor-Achievement-Mod/Mod.cs`](diffhunk://#diff-e74552123ebf64555f0d550b7ecc087475a498259f3d96ac96dc6a8af4f1679eL43-R77): Updated the `IsValidScene` method to check if the scene name exists in the `ValidScenes` array instead of comparing it to a single scene name.